### PR TITLE
fix: "Paypay" string in session.payment.ts

### DIFF
--- a/src/types/session.payment.ts
+++ b/src/types/session.payment.ts
@@ -77,7 +77,7 @@ export type PaymentSessionObject = {
         /**
          * Payment method types used for this session.
          */
-        pay_type: ("Card" | "Konbini" | "PayPay")[]
+        pay_type: ("Card" | "Konbini" | "Paypay")[]
 
         /**
          * Order ID.
@@ -244,9 +244,9 @@ export type CreatingPaymentSessionRequest = {
          * 
          * - `Card`: Card payment
          * - `Konbini`: Konbini payment
-         * - `PayPay`: PayPay payment
+         * - `Paypay`: PayPay payment
          */
-        pay_type?: ("Card" | "Konbini" | "PayPay")[] | null
+        pay_type?: ("Card" | "Konbini" | "Paypay")[] | null
 
         /**
          * Order ID.


### PR DESCRIPTION
[fincode API reference](https://docs.fincode.jp/api#tag/%E3%83%AA%E3%83%80%E3%82%A4%E3%83%AC%E3%82%AF%E3%83%88%E5%9E%8B/operation/postSessions) によると`transaction`内の`pay_type`は

- `Card`- カード決済
- `Konbini`- コンビニ決済
- `Paypay`- PayPay

ですが、このSDKの型では`Paypay`ではなく`PayPay`になっていました